### PR TITLE
feat(windsurf): Align with Wave 8 directory structure and trigger format

### DIFF
--- a/.ai-rulez/rules/source-of-truth-governance.md
+++ b/.ai-rulez/rules/source-of-truth-governance.md
@@ -5,6 +5,9 @@ targets:
   - .cursor/rules/*
   - .windsurf/*
   - .github/copilot-instructions.md
+trigger: model_decision
+description: Apply when working with AI tooling configuration
+
 ---
 
 # Source-of-Truth Governance

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -204,7 +204,7 @@ go 1.21`
 			case tool.config.Cursor:
 				assert.Contains(t, prompt, ".cursorrules")
 			case tool.config.Windsurf:
-				assert.Contains(t, prompt, ".windsurf/rules.md")
+				assert.Contains(t, prompt, ".windsurf/rules/")
 			}
 
 			assert.Contains(t, prompt, "# agents:")

--- a/internal/config/activation.go
+++ b/internal/config/activation.go
@@ -1,0 +1,92 @@
+package config
+
+// Trigger constants for Windsurf rules (matches Windsurf's actual field names)
+const (
+	TriggerManual        = "manual"         // Manual activation via @mention (default, no frontmatter needed)
+	TriggerAlwaysOn      = "always_on"      // Always active in every interaction
+	TriggerModelDecision = "model_decision" // AI decides based on context
+	TriggerGlob          = "glob"           // Activate based on file path patterns
+)
+
+// IsValidTriggerMode checks if the trigger mode is valid
+func IsValidTriggerMode(mode string) bool {
+	switch mode {
+	case TriggerManual, TriggerAlwaysOn, TriggerModelDecision, TriggerGlob:
+		return true
+	default:
+		return false
+	}
+}
+
+// GetTriggerMode retrieves the trigger mode from metadata
+// Returns "manual" as default if not specified or invalid
+func (m *MetadataV3) GetTriggerMode() string {
+	if m == nil {
+		return TriggerManual
+	}
+
+	mode, ok := m.Extra["trigger"]
+	if !ok {
+		return TriggerManual // default value
+	}
+
+	if !IsValidTriggerMode(mode) {
+		// Invalid mode, return default without blocking
+		// The generator will log a warning
+		return TriggerManual
+	}
+
+	return mode
+}
+
+// GetTriggerDescription retrieves the description for model_decision mode
+func (m *MetadataV3) GetTriggerDescription() string {
+	if m == nil {
+		return ""
+	}
+	return m.Extra["description"]
+}
+
+// GetTriggerGlob retrieves the glob pattern for glob mode
+func (m *MetadataV3) GetTriggerGlob() string {
+	if m == nil {
+		return ""
+	}
+	return m.Extra["glob"]
+}
+
+// GetTriggerKeywords retrieves the trigger keywords for manual mode
+func (m *MetadataV3) GetTriggerKeywords() []string {
+	if m == nil {
+		return nil
+	}
+
+	// Keywords can be stored as "keywords" in Extra
+	keywordsStr, ok := m.Extra["keywords"]
+	if !ok {
+		return nil
+	}
+
+	// For now, return as single-element slice
+	// In the future, we might want to parse comma-separated values
+	if keywordsStr != "" {
+		return []string{keywordsStr}
+	}
+
+	return nil
+}
+
+// ShouldRenderTriggerFrontmatter checks if trigger frontmatter should be rendered
+// Returns true if trigger mode is non-default or has additional config
+func (m *MetadataV3) ShouldRenderTriggerFrontmatter() bool {
+	if m == nil {
+		return false
+	}
+
+	mode := m.GetTriggerMode()
+	desc := m.GetTriggerDescription()
+	glob := m.GetTriggerGlob()
+
+	// Render if non-default mode or has extra config
+	return mode != TriggerManual || desc != "" || glob != ""
+}

--- a/internal/config/activation_test.go
+++ b/internal/config/activation_test.go
@@ -1,0 +1,279 @@
+package config
+
+import "testing"
+
+func TestIsValidTriggerMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		expected bool
+	}{
+		{
+			name:     "valid manual mode",
+			mode:     TriggerManual,
+			expected: true,
+		},
+		{
+			name:     "valid always_on mode",
+			mode:     TriggerAlwaysOn,
+			expected: true,
+		},
+		{
+			name:     "valid model_decision mode",
+			mode:     TriggerModelDecision,
+			expected: true,
+		},
+		{
+			name:     "valid glob mode",
+			mode:     TriggerGlob,
+			expected: true,
+		},
+		{
+			name:     "invalid mode",
+			mode:     "unknown",
+			expected: false,
+		},
+		{
+			name:     "empty mode",
+			mode:     "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsValidTriggerMode(tt.mode)
+			if result != tt.expected {
+				t.Errorf("IsValidTriggerMode(%q) = %v, want %v", tt.mode, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetTriggerMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *MetadataV3
+		expected string
+	}{
+		{
+			name:     "nil metadata returns manual",
+			metadata: nil,
+			expected: TriggerManual,
+		},
+		{
+			name:     "nil Extra returns manual",
+			metadata: &MetadataV3{},
+			expected: TriggerManual,
+		},
+		{
+			name: "empty Extra returns manual",
+			metadata: &MetadataV3{
+				Extra: map[string]string{},
+			},
+			expected: TriggerManual,
+		},
+		{
+			name: "valid manual mode",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "manual",
+				},
+			},
+			expected: TriggerManual,
+		},
+		{
+			name: "valid always_on mode",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "always_on",
+				},
+			},
+			expected: TriggerAlwaysOn,
+		},
+		{
+			name: "valid model_decision mode",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "model_decision",
+				},
+			},
+			expected: TriggerModelDecision,
+		},
+		{
+			name: "invalid mode returns manual (graceful degradation)",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "invalid_mode",
+				},
+			},
+			expected: TriggerManual, // degrades to default
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.metadata.GetTriggerMode()
+			if result != tt.expected {
+				t.Errorf("GetTriggerMode() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetTriggerDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *MetadataV3
+		expected string
+	}{
+		{
+			name:     "nil metadata returns empty",
+			metadata: nil,
+			expected: "",
+		},
+		{
+			name: "with description",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"description": "Apply when working with APIs",
+				},
+			},
+			expected: "Apply when working with APIs",
+		},
+		{
+			name: "without description",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "manual",
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.metadata.GetTriggerDescription()
+			if result != tt.expected {
+				t.Errorf("GetTriggerDescription() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetTriggerGlob(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *MetadataV3
+		expected string
+	}{
+		{
+			name:     "nil metadata returns empty",
+			metadata: nil,
+			expected: "",
+		},
+		{
+			name: "with glob pattern",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"glob": "**/*.ts",
+				},
+			},
+			expected: "**/*.ts",
+		},
+		{
+			name: "without glob",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "manual",
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.metadata.GetTriggerGlob()
+			if result != tt.expected {
+				t.Errorf("GetTriggerGlob() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestShouldRenderTriggerFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *MetadataV3
+		expected bool
+	}{
+		{
+			name:     "nil metadata returns false",
+			metadata: nil,
+			expected: false,
+		},
+		{
+			name:     "default manual mode with no extra returns false",
+			metadata: &MetadataV3{},
+			expected: false,
+		},
+		{
+			name: "explicit manual mode with no extra returns false",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "manual",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "model_decision mode returns true",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "model_decision",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "always_on mode returns true",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "always_on",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "manual mode with description returns true",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger":     "manual",
+					"description": "Apply for API files",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "manual mode with glob returns true",
+			metadata: &MetadataV3{
+				Extra: map[string]string{
+					"trigger": "manual",
+					"glob":    "**/*.ts",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.metadata.ShouldRenderTriggerFrontmatter()
+			if result != tt.expected {
+				t.Errorf("ShouldRenderTriggerFrontmatter() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -17,7 +17,7 @@ var PresetRegistry = map[string][]Output{
 		{Path: ".gemini/settings.json", Template: Template{Type: TemplateBuiltin, Value: "gemini-mcp"}},
 	},
 	"windsurf": {
-		{Path: ".windsurf/", Type: "rule", NamingScheme: "{name}.md"},
+		{Path: ".windsurf/rules/", Type: "rule", NamingScheme: "{name}.md"},
 	},
 	"cline": {
 		{Path: ".clinerules/", Type: "rule", NamingScheme: "{name}.md"},
@@ -43,7 +43,7 @@ var PresetRegistry = map[string][]Output{
 		{Path: "AGENTS.md"},
 		{Path: ".mcp.json", Template: Template{Type: TemplateBuiltin, Value: "claude-code-mcp"}},
 		{Path: ".cursor/rules/", Type: "rule", NamingScheme: "{name}.mdc"},
-		{Path: ".windsurf/", Type: "rule", NamingScheme: "{name}.md"},
+		{Path: ".windsurf/rules/", Type: "rule", NamingScheme: "{name}.md"},
 		{Path: ".gemini/settings.json", Template: Template{Type: TemplateBuiltin, Value: "gemini-mcp"}},
 		{Path: ".github/copilot-instructions.md"},
 		{Path: "GEMINI.md"},

--- a/internal/generator/presets/windsurf.go
+++ b/internal/generator/presets/windsurf.go
@@ -1,11 +1,13 @@
 package presets
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/Goldziher/ai-rulez/internal/config"
+	"github.com/Goldziher/ai-rulez/internal/logger"
 	"github.com/Goldziher/ai-rulez/internal/markdown"
 	"github.com/Goldziher/ai-rulez/internal/templates"
 )
@@ -40,16 +42,16 @@ func (g *WindsurfPresetGenerator) GetName() string {
 
 func (g *WindsurfPresetGenerator) GetOutputPaths(baseDir string) []string {
 	return []string{
-		filepath.Join(baseDir, ".windsurf"),
+		filepath.Join(baseDir, ".windsurf", "rules"),
 	}
 }
 
 func (g *WindsurfPresetGenerator) Generate(content *config.ContentTreeV3, baseDir string, cfg *config.ConfigV3) ([]config.OutputFileV3, error) {
 	var outputs []config.OutputFileV3
 
-	// Create .windsurf directory
+	// Create .windsurf/rules directory
 	outputs = append(outputs, config.OutputFileV3{
-		Path:  filepath.Join(baseDir, ".windsurf"),
+		Path:  filepath.Join(baseDir, ".windsurf", "rules"),
 		IsDir: true,
 	})
 
@@ -58,12 +60,12 @@ func (g *WindsurfPresetGenerator) Generate(content *config.ContentTreeV3, baseDi
 
 	// Generate rule files
 	for _, rule := range allRules {
-		outputPath := filepath.Join(".windsurf", sanitizeName(rule.Name)+".md")
+		outputPath := filepath.Join(".windsurf", "rules", sanitizeName(rule.Name)+".md")
 		ruleContent := g.renderRuleFile(rule, cfg, outputPath, len(allRules))
 		sanitized := sanitizeName(rule.Name)
 
 		outputs = append(outputs, config.OutputFileV3{
-			Path:    filepath.Join(baseDir, ".windsurf", sanitized+".md"),
+			Path:    filepath.Join(baseDir, ".windsurf", "rules", sanitized+".md"),
 			Content: ruleContent,
 		})
 	}
@@ -71,10 +73,62 @@ func (g *WindsurfPresetGenerator) Generate(content *config.ContentTreeV3, baseDi
 	return outputs, nil
 }
 
+// renderTriggerFrontmatter renders Windsurf trigger frontmatter if needed
+func (g *WindsurfPresetGenerator) renderTriggerFrontmatter(builder *strings.Builder, rule config.ContentFile) {
+	if rule.Metadata == nil {
+		return
+	}
+
+	// Check if we should render trigger frontmatter
+	if !rule.Metadata.ShouldRenderTriggerFrontmatter() {
+		return
+	}
+
+	mode := rule.Metadata.GetTriggerMode()
+
+	// Validate mode and warn if invalid
+	if !config.IsValidTriggerMode(mode) {
+		logger.Warn(
+			"Unknown trigger mode in Windsurf rule, using default",
+			"mode", mode,
+			"rule", rule.Name,
+			"default", config.TriggerManual,
+		)
+		mode = config.TriggerManual
+	}
+
+	// Only render if non-default
+	if mode == config.TriggerManual {
+		desc := rule.Metadata.GetTriggerDescription()
+		glob := rule.Metadata.GetTriggerGlob()
+
+		// Still render if has extra config
+		if desc == "" && glob == "" {
+			return
+		}
+	}
+
+	builder.WriteString("---\n")
+	fmt.Fprintf(builder, "trigger: %s\n", mode)
+
+	if desc := rule.Metadata.GetTriggerDescription(); desc != "" {
+		fmt.Fprintf(builder, "description: %s\n", desc)
+	}
+
+	if glob := rule.Metadata.GetTriggerGlob(); glob != "" {
+		fmt.Fprintf(builder, "glob: %s\n", glob)
+	}
+
+	builder.WriteString("---\n\n")
+}
+
 func (g *WindsurfPresetGenerator) renderRuleFile(rule config.ContentFile, cfg *config.ConfigV3, outputPath string, ruleCount int) string {
 	var builder strings.Builder
 
-	// Generate and prepend header
+	// Render trigger frontmatter FIRST (must be at line 1 for Windsurf)
+	g.renderTriggerFrontmatter(&builder, rule)
+
+	// Generate and add header after frontmatter
 	header := generateWindsurfPresetHeader(cfg, outputPath, ruleCount, 0, 0)
 	builder.WriteString(header)
 

--- a/internal/generator/presets/windsurf_test.go
+++ b/internal/generator/presets/windsurf_test.go
@@ -1,0 +1,225 @@
+package presets
+
+import (
+	"testing"
+
+	"github.com/Goldziher/ai-rulez/internal/config"
+)
+
+func TestWindsurfPresetGenerator_Generate(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     *config.ContentTreeV3
+		baseDir     string
+		wantOutputs int
+		wantErr     bool
+	}{
+		{
+			name: "generates rule files",
+			content: &config.ContentTreeV3{
+				Rules: []config.ContentFile{
+					{
+						Name:    "Test Rule",
+						Content: "Rule content here",
+					},
+				},
+			},
+			baseDir:     "/test",
+			wantOutputs: 2, // 1 directory + 1 file
+			wantErr:     false,
+		},
+		{
+			name: "generates multiple rule files",
+			content: &config.ContentTreeV3{
+				Rules: []config.ContentFile{
+					{
+						Name:    "Rule One",
+						Content: "First rule",
+					},
+					{
+						Name:    "Rule Two",
+						Content: "Second rule",
+					},
+				},
+			},
+			baseDir:     "/test",
+			wantOutputs: 3, // 1 directory + 2 files
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &WindsurfPresetGenerator{}
+			cfg := &config.ConfigV3{
+				Name: "Test Project",
+			}
+
+			outputs, err := g.Generate(tt.content, tt.baseDir, cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Generate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(outputs) != tt.wantOutputs {
+				t.Errorf("Generate() got %d outputs, want %d", len(outputs), tt.wantOutputs)
+			}
+		})
+	}
+}
+
+func TestWindsurfPresetGenerator_TriggerFrontmatter(t *testing.T) {
+	tests := []struct {
+		name             string
+		rule             config.ContentFile
+		shouldContain    string
+		shouldNotContain string
+	}{
+		{
+			name: "no trigger - no frontmatter",
+			rule: config.ContentFile{
+				Name:    "Test Rule",
+				Content: "Rule content",
+			},
+			shouldContain:    "# Test Rule",
+			shouldNotContain: "---\ntrigger:",
+		},
+		{
+			name: "manual mode - no frontmatter (default)",
+			rule: config.ContentFile{
+				Name:    "Manual Rule",
+				Content: "Content",
+				Metadata: &config.MetadataV3{
+					Extra: map[string]string{
+						"trigger": "manual",
+					},
+				},
+			},
+			shouldContain:    "# Manual Rule",
+			shouldNotContain: "---\ntrigger: manual",
+		},
+		{
+			name: "always_on mode - generates frontmatter",
+			rule: config.ContentFile{
+				Name:    "Always Rule",
+				Content: "Content",
+				Metadata: &config.MetadataV3{
+					Extra: map[string]string{
+						"trigger": "always_on",
+					},
+				},
+			},
+			shouldContain:    "---\ntrigger: always_on",
+			shouldNotContain: "",
+		},
+		{
+			name: "model_decision mode with description - generates frontmatter",
+			rule: config.ContentFile{
+				Name:    "Smart Rule",
+				Content: "Content",
+				Metadata: &config.MetadataV3{
+					Extra: map[string]string{
+						"trigger":     "model_decision",
+						"description": "Apply when working with APIs",
+					},
+				},
+			},
+			shouldContain:    "description: Apply when working with APIs",
+			shouldNotContain: "",
+		},
+		{
+			name: "glob mode with pattern - generates frontmatter",
+			rule: config.ContentFile{
+				Name:    "Glob Rule",
+				Content: "Content",
+				Metadata: &config.MetadataV3{
+					Extra: map[string]string{
+						"trigger": "glob",
+						"glob":    "**/*.ts",
+					},
+				},
+			},
+			shouldContain:    "glob: **/*.ts",
+			shouldNotContain: "",
+		},
+		{
+			name: "model_decision mode - generates frontmatter",
+			rule: config.ContentFile{
+				Name:    "Auto Rule",
+				Content: "Content",
+				Metadata: &config.MetadataV3{
+					Extra: map[string]string{
+						"trigger": "model_decision",
+					},
+				},
+			},
+			shouldContain:    "---\ntrigger: model_decision",
+			shouldNotContain: "",
+		},
+		{
+			name: "invalid mode - falls back to manual, no frontmatter",
+			rule: config.ContentFile{
+				Name:    "Invalid Rule",
+				Content: "Content",
+				Metadata: &config.MetadataV3{
+					Extra: map[string]string{
+						"trigger": "invalid_mode",
+					},
+				},
+			},
+			shouldContain:    "# Invalid Rule",
+			shouldNotContain: "---\ntrigger: invalid_mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &WindsurfPresetGenerator{}
+			cfg := &config.ConfigV3{
+				Name: "Test Project",
+			}
+
+			result := g.renderRuleFile(tt.rule, cfg, "/test/.windsurf/rules/test.md", 1)
+
+			if tt.shouldContain != "" && !contains(result, tt.shouldContain) {
+				t.Errorf("Expected output to contain %q, but it didn't", tt.shouldContain)
+			}
+
+			if tt.shouldNotContain != "" && contains(result, tt.shouldNotContain) {
+				t.Errorf("Expected output NOT to contain %q, but it did", tt.shouldNotContain)
+			}
+		})
+	}
+}
+
+func TestWindsurfPresetGenerator_GetName(t *testing.T) {
+	g := &WindsurfPresetGenerator{}
+	if got := g.GetName(); got != "windsurf" {
+		t.Errorf("GetName() = %v, want %v", got, "windsurf")
+	}
+}
+
+func TestWindsurfPresetGenerator_GetOutputPaths(t *testing.T) {
+	g := &WindsurfPresetGenerator{}
+	paths := g.GetOutputPaths("/test/base")
+	if len(paths) != 1 {
+		t.Errorf("GetOutputPaths() returned %d paths, want 1", len(paths))
+	}
+	if paths[0] != "/test/base/.windsurf/rules" {
+		t.Errorf("GetOutputPaths()[0] = %v, want %v", paths[0], "/test/base/.windsurf/rules")
+	}
+}
+
+// Helper function
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -66,7 +66,7 @@ func (i *Importer) Import(sources string) error {
 
 		if len(sourcesToImport) == 0 {
 			return oops.
-				Hint("No existing AI tool files found to import\nSupported: CLAUDE.md, .claude/, .cursor/, .windsurf/, .gemini/, .github/copilot-instructions.md, .continue/, .clinerules/").
+				Hint("No existing AI tool files found to import\nSupported: CLAUDE.md, .claude/, .cursor/, .windsurf/, .windsurf/rules/, .gemini/, .github/copilot-instructions.md, .continue/, .clinerules/").
 				Errorf("no sources detected for import")
 		}
 
@@ -151,6 +151,7 @@ func (i *Importer) detectSources() ([]string, error) {
 		".claude/agents",
 		".cursor/rules",
 		".windsurf",
+		".windsurf/rules",
 		".continue/rules",
 		".continue/prompts",
 		".clinerules",
@@ -338,7 +339,7 @@ func (i *Importer) importCursorRules(source, path string) ([]ImportedContent, st
 	return i.importGenericMarkdownDirectory(source, path)
 }
 
-// importWindsurfRules imports from .windsurf/ directory
+// importWindsurfRules imports from .windsurf/ or .windsurf/rules/ directory
 func (i *Importer) importWindsurfRules(source, path string) ([]ImportedContent, string, error) {
 	return i.importGenericMarkdownDirectory(source, path)
 }

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -427,7 +427,7 @@ func TestDetectPresetFromSource(t *testing.T) {
 		{"GEMINI.md", "gemini"},
 		{".github/copilot-instructions.md", "copilot"},
 		{".continue/rules", "continue-dev"},
-		{".windsurf", "windsurf"},
+		{".windsurf/rules", "windsurf"},
 		{".clinerules", "cline"},
 		{"unknown.md", ""},
 	}

--- a/internal/templates/providers.go
+++ b/internal/templates/providers.go
@@ -37,7 +37,7 @@ func getDefaultOutputPath(providers ProviderConfig) string {
 		return "AGENTS.md"
 	}
 	if providers.Windsurf {
-		return ".windsurf/rules.md"
+		return ".windsurf/rules/01-main.md"
 	}
 	if providers.Copilot {
 		return ".github/copilot-instructions.md"
@@ -70,8 +70,8 @@ func writeProviderOutputs(builder *strings.Builder, providers ProviderConfig) {
 	}
 
 	if providers.Windsurf {
-		builder.WriteString(`  - path: ".windsurf/"
-    type: "rule" 
+		builder.WriteString(`  - path: ".windsurf/rules/"
+    type: "rule"
     naming_scheme: "{name}.md"
 `)
 	}


### PR DESCRIPTION
## Summary

This PR updates the Windsurf preset generator to align with the Wave 8 directory structure and trigger frontmatter format.

Closes #70

## Changes

### Core Implementation

#### `internal/config/activation.go` (new file)
- Defines trigger mode constants: `manual`, `always_on`, `model_decision`, `glob`
- `GetTriggerMode()` - retrieves trigger mode from metadata (defaults to `manual`)
- `GetTriggerDescription()` - retrieves description for `model_decision` mode
- `GetTriggerGlob()` - retrieves glob pattern for `glob` mode
- `ShouldRenderTriggerFrontmatter()` - determines if frontmatter should be rendered

#### `internal/generator/presets/windsurf.go`
- Changed output from single `.windsurf/rules.md` to directory-based `.windsurf/rules/*.md`
- Added `renderTriggerFrontmatter()` to generate Wave 8 compliant frontmatter
- **Frontmatter is now rendered at line 1** (before the AI-RULEZ header comment)
- Only renders frontmatter for non-default modes or when extra config is present

### Test Coverage

- `internal/config/activation_test.go` - comprehensive tests for trigger mode logic
- `internal/generator/presets/windsurf_test.go` - tests for frontmatter rendering
- Fixed `internal/agents/agents_test.go` to match new directory structure

## Trigger Modes

| Mode | Frontmatter | Description |
|------|-------------|-------------|
| `manual` | Not rendered (default) | Activated via @mention |
| `always_on` | Rendered | Always active |
| `model_decision` | Rendered | AI decides based on context |
| `glob` | Rendered | File path pattern matching |

## Example Output

**Source** (`.ai-rulez/rules/typescript.md`):
```yaml
---
trigger: model_decision
description: Apply when working with TypeScript
---
# TypeScript Rule
Content...
```

**Generated** (`.windsurf/rules/typescript.md`):
```markdown
---
trigger: model_decision
description: Apply when working with TypeScript
---

<!-- AI-RULEZ header... -->

# typescript
```

## Checklist

- [x] Code follows project style guidelines
- [x] All new code has test coverage
- [x] Tests pass locally
- [x] No new lint errors introduced