### PR TITLE
fix: discover and scan domains from included sources

### DIFF
--- a/internal/includes/git.go
+++ b/internal/includes/git.go
@@ -149,13 +149,21 @@ func (s *GitSource) Fetch(ctx context.Context) (*config.ContentTreeV3, error) {
 
 	logger.Debug("Found .ai-rulez directory", "path", aiRulezDir)
 
-	// Create a minimal config for the scanner
+	// Discover domains in the include so they get scanned
+	domains := discoverDomains(aiRulezDir)
+	if len(domains) > 0 {
+		logger.Debug("Discovered domains in include", "name", s.name, "domains", domains)
+	}
+
+	// Create a minimal config for the scanner with discovered domains
+	// Set Default to "default" so ScanProfile("") uses the default profile with domains
 	minimalConfig := &config.ConfigV3{
 		Version: "3.0",
 		Name:    s.name,
 		BaseDir: filepath.Dir(aiRulezDir),
+		Default: "default",
 		Profiles: map[string][]string{
-			"default": {}, // Empty default profile
+			"default": domains, // Include discovered domains so they get scanned
 		},
 	}
 

--- a/internal/includes/local.go
+++ b/internal/includes/local.go
@@ -98,13 +98,23 @@ func (s *LocalSource) Fetch(ctx context.Context) (*config.ContentTreeV3, error) 
 		}()
 	}
 
-	// Create a minimal config for the scanner
+	// Discover domains in the include so they get scanned
+	// For local includes, the .ai-rulez dir is at baseDir/.ai-rulez
+	localAIRulezDir := filepath.Join(baseDir, ".ai-rulez")
+	domains := discoverDomains(localAIRulezDir)
+	if len(domains) > 0 {
+		logger.Debug("Discovered domains in local include", "name", s.name, "domains", domains)
+	}
+
+	// Create a minimal config for the scanner with discovered domains
+	// Set Default to "default" so ScanProfile("") uses the default profile with domains
 	minimalConfig := &config.ConfigV3{
 		Version: "3.0",
 		Name:    s.name,
 		BaseDir: baseDir,
+		Default: "default",
 		Profiles: map[string][]string{
-			"default": {}, // Empty default profile
+			"default": domains, // Include discovered domains so they get scanned
 		},
 	}
 

--- a/internal/includes/local_test.go
+++ b/internal/includes/local_test.go
@@ -484,3 +484,164 @@ func TestFetchWithFiltering(t *testing.T) {
 		t.Error("expected skills to be filtered out")
 	}
 }
+
+// Test that domains are discovered and scanned from includes
+func TestLocalSourceFetchWithDomains(t *testing.T) {
+	// Arrange - create a temp directory with .ai-rulez structure including domains
+	tmpDir := t.TempDir()
+	aiRulezDir := createTestAIRulezDir(t, tmpDir)
+
+	// Create domains in the .ai-rulez directory
+	backendDomainDir := filepath.Join(aiRulezDir, "domains", "backend", "rules")
+	if err := os.MkdirAll(backendDomainDir, 0755); err != nil {
+		t.Fatalf("failed to create backend domain: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(backendDomainDir, "api.md"), []byte("# API Rules"), 0644); err != nil {
+		t.Fatalf("failed to write backend rule: %v", err)
+	}
+
+	frontendDomainDir := filepath.Join(aiRulezDir, "domains", "frontend", "rules")
+	if err := os.MkdirAll(frontendDomainDir, 0755); err != nil {
+		t.Fatalf("failed to create frontend domain: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(frontendDomainDir, "components.md"), []byte("# Component Rules"), 0644); err != nil {
+		t.Fatalf("failed to write frontend rule: %v", err)
+	}
+
+	source := NewLocalSource("test", tmpDir, tmpDir, nil)
+	ctx := context.Background()
+
+	// Act
+	contentTree, err := source.Fetch(ctx)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if contentTree == nil {
+		t.Fatalf("expected non-nil ContentTreeV3")
+	}
+
+	// Verify domains were discovered and scanned
+	if contentTree.Domains == nil {
+		t.Fatal("expected Domains map to be non-nil")
+	}
+	if len(contentTree.Domains) != 2 {
+		t.Errorf("expected 2 domains, got %d", len(contentTree.Domains))
+	}
+
+	backend, hasBackend := contentTree.Domains["backend"]
+	if !hasBackend {
+		t.Error("expected backend domain to be discovered")
+	} else if len(backend.Rules) == 0 {
+		t.Error("expected backend domain to have rules")
+	}
+
+	frontend, hasFrontend := contentTree.Domains["frontend"]
+	if !hasFrontend {
+		t.Error("expected frontend domain to be discovered")
+	} else if len(frontend.Rules) == 0 {
+		t.Error("expected frontend domain to have rules")
+	}
+}
+
+// Test discoverDomains helper function
+func TestDiscoverDomains(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupFunc       func(t *testing.T, dir string)
+		expectedDomains []string
+	}{
+		{
+			name: "no domains directory",
+			setupFunc: func(t *testing.T, dir string) {
+				// Don't create domains directory
+			},
+			expectedDomains: nil,
+		},
+		{
+			name: "empty domains directory",
+			setupFunc: func(t *testing.T, dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, "domains"), 0755); err != nil {
+					t.Fatalf("failed to create domains dir: %v", err)
+				}
+			},
+			expectedDomains: nil,
+		},
+		{
+			name: "single domain",
+			setupFunc: func(t *testing.T, dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, "domains", "backend"), 0755); err != nil {
+					t.Fatalf("failed to create domain: %v", err)
+				}
+			},
+			expectedDomains: []string{"backend"},
+		},
+		{
+			name: "multiple domains",
+			setupFunc: func(t *testing.T, dir string) {
+				for _, domain := range []string{"backend", "frontend", "qa"} {
+					if err := os.MkdirAll(filepath.Join(dir, "domains", domain), 0755); err != nil {
+						t.Fatalf("failed to create domain %s: %v", domain, err)
+					}
+				}
+			},
+			expectedDomains: []string{"backend", "frontend", "qa"},
+		},
+		{
+			name: "ignores files in domains directory",
+			setupFunc: func(t *testing.T, dir string) {
+				domainsDir := filepath.Join(dir, "domains")
+				if err := os.MkdirAll(domainsDir, 0755); err != nil {
+					t.Fatalf("failed to create domains dir: %v", err)
+				}
+				// Create a directory (domain)
+				if err := os.MkdirAll(filepath.Join(domainsDir, "backend"), 0755); err != nil {
+					t.Fatalf("failed to create domain: %v", err)
+				}
+				// Create a file (should be ignored)
+				if err := os.WriteFile(filepath.Join(domainsDir, "README.md"), []byte("readme"), 0644); err != nil {
+					t.Fatalf("failed to create file: %v", err)
+				}
+			},
+			expectedDomains: []string{"backend"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			aiRulezDir := filepath.Join(tmpDir, ".ai-rulez")
+			if err := os.MkdirAll(aiRulezDir, 0755); err != nil {
+				t.Fatalf("failed to create .ai-rulez: %v", err)
+			}
+
+			tt.setupFunc(t, aiRulezDir)
+
+			domains := discoverDomains(aiRulezDir)
+
+			if tt.expectedDomains == nil {
+				if len(domains) != 0 {
+					t.Errorf("expected no domains, got %v", domains)
+				}
+				return
+			}
+
+			if len(domains) != len(tt.expectedDomains) {
+				t.Errorf("expected %d domains, got %d: %v", len(tt.expectedDomains), len(domains), domains)
+				return
+			}
+
+			// Check all expected domains are present (order may vary)
+			domainSet := make(map[string]bool)
+			for _, d := range domains {
+				domainSet[d] = true
+			}
+			for _, expected := range tt.expectedDomains {
+				if !domainSet[expected] {
+					t.Errorf("expected domain %q not found in %v", expected, domains)
+				}
+			}
+		})
+	}
+}

--- a/internal/includes/source.go
+++ b/internal/includes/source.go
@@ -2,6 +2,8 @@ package includes
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Goldziher/ai-rulez/internal/config"
@@ -50,4 +52,32 @@ func IsGitURL(source string) bool {
 // IsLocalPath checks if a source string is a local file path
 func IsLocalPath(source string) bool {
 	return DetectSourceType(source) == SourceTypeLocal
+}
+
+// discoverDomains scans the domains/ directory within an .ai-rulez directory
+// and returns a list of domain names. This is used when scanning includes
+// to ensure all domains from the included source are discovered and scanned.
+func discoverDomains(aiRulezDir string) []string {
+	domainsDir := filepath.Join(aiRulezDir, "domains")
+
+	// Check if domains directory exists
+	info, err := os.Stat(domainsDir)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	// Read domain subdirectories
+	entries, err := os.ReadDir(domainsDir)
+	if err != nil {
+		return nil
+	}
+
+	var domains []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			domains = append(domains, entry.Name())
+		}
+	}
+
+	return domains
 }


### PR DESCRIPTION
## Summary

When fetching content from includes (both git and local), domains were never scanned because the scanner was created with a minimal config that had an empty default profile. This meant that profiles referencing domains from remote includes would show "profile references non-existent domain" warnings, and the domain content was never included.

## Changes

- Added `discoverDomains()` helper function in `source.go` to scan the `domains/` directory
- Updated `GitSource.Fetch()` to discover domains before scanning
- Updated `LocalSource.Fetch()` to discover domains before scanning  
- Set `Default: "default"` in minimal config so `ScanProfile("")` uses discovered domains
- Added comprehensive tests for domain discovery functionality

## Test plan

- [x] Added `TestLocalSourceFetchWithDomains` - verifies domains are discovered and scanned from local includes
- [x] Added `TestDiscoverDomains` - unit tests for the helper function covering edge cases
- [x] All existing includes tests pass
- [x] `go build ./...` succeeds

## Related issue

Fixes the issue where domains defined in remote includes were not being scanned, causing profiles that reference those domains to fail validation with "profile references non-existent domain" warnings.