### PR TITLE
fix(claude): emit `type` not `transport` for http/sse MCP servers

### DIFF
--- a/internal/generator/providers/providers_test.go
+++ b/internal/generator/providers/providers_test.go
@@ -363,6 +363,20 @@ func TestClaude_SettingsJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(settings.Content), &parsed))
 	servers := parsed["mcpServers"].(map[string]any)
 	assert.Len(t, servers, 2)
+
+	// Remote (http/sse) servers must use Claude Code's `type` key, carry no
+	// command, and must not emit the `transport` key. See
+	// https://code.claude.com/docs/en/mcp.
+	httpEntry := servers["http-server"].(map[string]any)
+	assert.Equal(t, "http", httpEntry["type"], "remote server must use the `type` key")
+	assert.Equal(t, "http://localhost:8080", httpEntry["url"])
+	assert.NotContains(t, httpEntry, "transport", "must not emit `transport`; Claude Code keys on `type`")
+	assert.NotContains(t, httpEntry, "command", "remote server must not carry a command")
+
+	// stdio servers are unchanged: command-based, no `type` key.
+	stdioEntry := servers["test-server"].(map[string]any)
+	assert.Equal(t, "npx", stdioEntry["command"], "stdio server keeps its command")
+	assert.NotContains(t, stdioEntry, "type", "stdio server must not emit a `type` key")
 }
 
 // TestClaude_PluginsJSON covers the plugins-aware plugins.json sidecar

--- a/internal/generator/providers/sidecars.go
+++ b/internal/generator/providers/sidecars.go
@@ -69,17 +69,22 @@ func renderMCPJSON(cfg *config.Config) (string, error) {
 	mcpServers := make(map[string]any)
 	for name, server := range cfg.MCPServers {
 		entry := map[string]any{
-			"command":  server.Command,
 			"disabled": !server.IsEnabled(),
 		}
-		if len(server.Args) > 0 {
-			entry["args"] = server.Args
+		// Claude Code keys remote transport on `type` (accepting "http", "sse",
+		// or "streamable-http"); a stdio entry with an empty command is invalid.
+		// See https://code.claude.com/docs/en/mcp.
+		switch t := server.GetTransport(); t {
+		case "http", "sse":
+			entry["type"] = t
+		default:
+			entry["command"] = server.Command
+			if len(server.Args) > 0 {
+				entry["args"] = server.Args
+			}
 		}
 		if len(server.Env) > 0 {
 			entry["env"] = server.Env
-		}
-		if server.Transport != "" {
-			entry["transport"] = server.GetTransport()
 		}
 		if server.URL != "" {
 			entry["url"] = server.URL
@@ -113,17 +118,21 @@ func (g *Generator) renderAmpSettingsJSON(cfg *config.Config) (string, error) {
 func renderClaudeSettingsJSON(cfg *config.Config) (string, error) {
 	mcpServers := make(map[string]any)
 	for name, server := range cfg.MCPServers {
-		entry := map[string]any{
-			"command": server.Command,
-		}
-		if len(server.Args) > 0 {
-			entry["args"] = server.Args
+		entry := map[string]any{}
+		// Claude Code keys remote transport on `type` (accepting "http", "sse",
+		// or "streamable-http"); a stdio entry with an empty command is invalid.
+		// See https://code.claude.com/docs/en/mcp.
+		switch t := server.GetTransport(); t {
+		case "http", "sse":
+			entry["type"] = t
+		default:
+			entry["command"] = server.Command
+			if len(server.Args) > 0 {
+				entry["args"] = server.Args
+			}
 		}
 		if len(server.Env) > 0 {
 			entry["env"] = server.Env
-		}
-		if server.Transport != "" {
-			entry["transport"] = server.GetTransport()
 		}
 		if server.URL != "" {
 			entry["url"] = server.URL

--- a/tests/e2e/v4_generation_test.go
+++ b/tests/e2e/v4_generation_test.go
@@ -680,11 +680,12 @@ func (s *V4GenerationSuite) TestMCP_Content() {
 	s.Assert().Contains(args, "-y")
 	s.Assert().Contains(args, "@test/mcp-server")
 
-	// http-mcp-server with transport and url
+	// http-mcp-server uses Claude Code's `type` key (not `transport`) and carries no command
 	httpServer, ok := mcpServers["http-mcp-server"].(map[string]interface{})
 	s.Require().True(ok, "Should have http-mcp-server entry")
-	s.Assert().Equal("http", httpServer["transport"])
+	s.Assert().Equal("http", httpServer["type"])
 	s.Assert().Equal("http://localhost:8080", httpServer["url"])
+	s.Assert().NotContains(httpServer, "transport", "Claude Code keys remote transport on `type`, not `transport`")
 }
 
 // ==========================================


### PR DESCRIPTION
Fixes #136.

## Problem

The Claude-target MCP renderers emit `transport` (plus an empty `command`) for `http`/`sse` servers, but Claude Code keys remote transport on **`type`** and rejects a stdio entry with an empty `command`. So a `transport = "http"` server generates `{"command":"","transport":"http","url":"…"}`, which Claude Code does not load.

## Fix

In `internal/generator/providers/sidecars.go`, both `renderMCPJSON` (`.mcp.json`) and `renderClaudeSettingsJSON` (`.claude/settings.json`):

- **http/sse** → emit `"type": <transport>` and `"url"`; omit `command`/`args`.
- **stdio** → unchanged (`command`/`args`).

The generic non-Claude presets (cursor, gemini, …) are intentionally left as-is, since their schemas use `transport`.

Resulting Claude Code output for a remote server:

```json
{ "type": "http", "url": "https://example.com/mcp" }
```

## Provenance

- Claude Code MCP docs — *"the `type` field accepts `streamable-http` as an alias for `http`"*: https://code.claude.com/docs/en/mcp
- MCP specification 2025-11-25, Streamable HTTP transport: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports

## Tests

- Extended `TestClaude_SettingsJSON` to assert the http server emits `type` (not `transport`), carries no `command`, and that stdio servers are unchanged.
- Updated the `.mcp.json` e2e assertion (`TestMCP_Content`) to expect `type`.
- `go test ./...` passes (28 packages); `gofmt` and `go vet` clean.
